### PR TITLE
Use double quotes in IDB example

### DIFF
--- a/gdal/ogr/ogrsf_frmts/idb/drv_idb.html
+++ b/gdal/ogr/ogrsf_frmts/idb/drv_idb.html
@@ -43,7 +43,7 @@ Informix Client SDK
 <p>This example shows using ogrinfo to list Informix DataBlade layers on a different host.
 
 <pre>
-ogrinfo -ro IDB:'server=demo_on user=informix dbname=frames'
+ogrinfo -ro IDB:"server=demo_on user=informix dbname=frames"
 </pre>
 
 </body>


### PR DESCRIPTION
Rationale: when using single quotes from a windows command prompt, connection will fail without a clear indication what is wrong. I broke my head on this earlier today.

Note that this actually applies to other examples as well, eg postgres. I'm willing to review the other examples as well if we can agree double quotes should be prefered in examples.
